### PR TITLE
렉페이지 로딩시 버그발생!!!

### DIFF
--- a/02.Code/gori/src/components/Lec.vue
+++ b/02.Code/gori/src/components/Lec.vue
@@ -124,7 +124,10 @@ export default {
 
       // 3. talent Questions
       this.questionload()
-
+  },
+  beforeDestroy(){
+    this.$store.commit("pageChangeReview", 1)
+    this.$store.commit("pageChange", 1)
 
 
 
@@ -202,13 +205,13 @@ export default {
 
   <style lang="sass">
     .lec-wrap
-      min-height: 10000px
+      min-height: 100vh
     [v-cloak]
       display: none
 
 
     .fade-enter-active, .fade-leave-active
-      transition: opacity 1s
+      transition: opacity 2s
 
     .fade-enter, .fade-leave-to
       opacity: 0

--- a/02.Code/gori/src/components/Lec_review.vue
+++ b/02.Code/gori/src/components/Lec_review.vue
@@ -83,7 +83,7 @@ export default {
       this.$emit('reflesh')
     },
     whiteSpace(text){
-      return text.replace(/\r\n/gi,"<br>")
+      return text.replace(/\r\n|\r|\n/gi,"<br>")
     },
     changePage(n){
       this.$store.commit("pageChangeReview", n)


### PR DESCRIPTION
페이지 이동시 가끔 lec-page 진입이 안되는 현상이 발견!!
1. 원인
lec-page의 리뷰와 문의하기가 page 단위로 보여주게 되어 있었고, 가령 리뷰가 3페이지 존재하는 곳에서 3페이지를 클릭시 해당 페이지를 컨트롤 하는 변수가 store에 저장 되어 있었음.
그후 리뷰가 2페이지만 존재하는 다른 lec페이지로 진입시. 페이지3을 찾지 못해 lec 페이지 진입자체가 안되는 현상이었음.

2. 해결방법
라이프 사이클 중 beforeDestroy를 이용하여 lec 페이지에서 빠져 나올 때 페이지수를 컨트롤 하는 변수를 1 로 바꾸어 놓음

3. 냐하하하하하